### PR TITLE
修复登录流程

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -1,0 +1,10 @@
+{
+  "login": {
+    "account": "20235206XXX",
+    "password": "XXXXX"
+  },
+  "daemon": {
+    "host": "http://10.9.1.3/",
+    "frequencies": 10
+  }
+}

--- a/daemon.py
+++ b/daemon.py
@@ -52,22 +52,46 @@ def check(chrome, host):
     return successed, message
 
 
-def login(chrome, u='', p=''):
-    # 选择'普通登录'
-    # chrome.find_element_by_xpath('//*[@id="edit_body"]/div[1]/div[3]/div/div[1]/span[1]').click()
 
-    account_input_xpath = '//*[@id="edit_body"]/div[2]/div[4]/div/div[2]/div[1]/div/form/input[3]'
-    password_input_xpath = '//*[@id="edit_body"]/div[2]/div[4]/div/div[2]/div[1]/div/form/input[4]'
-    login_bt_xpath = '//*[@id="edit_body"]/div[2]/div[4]/div/div[2]/div[1]/div/form/input[2]'
+def login(chrome, u='', p=''):
+    # ==================== 新增代码开始 ====================
+    try:
+
+        dropdown_xpath = '//*[@id="edit_body"]/div[2]/div[12]/select'
+        chrome.find_element_by_xpath(dropdown_xpath).click()
+
+        time.sleep(1)
+
+
+        operator_xpath = '//*[@id="edit_body"]/div[2]/div[12]/select/option[3]'
+        chrome.find_element_by_xpath(operator_xpath).click()
+        
+        time.sleep(1)
+        
+    except Exception as e:
+        logger.error('选择运营商时出错！请检查下拉菜单的XPath是否正确。', exc_info=True)
+        return # 直接退出login函数
+
+    # ==================== 新增代码结束 ====================
+	
+    account_input_xpath = '//*[@id="edit_body"]/div[2]/div[12]/form/input[3]'
+    password_input_xpath = '//*[@id="edit_body"]/div[2]/div[12]/form/input[4]'
+    login_bt_xpath = '//*[@id="edit_body"]/div[2]/div[12]/form/input[2]'
 
     account_input = chrome.find_element_by_xpath(account_input_xpath)
     password_input = chrome.find_element_by_xpath(password_input_xpath)
     login_bt = chrome.find_element_by_xpath(login_bt_xpath)
+    
+    account_input.click()      
+    time.sleep(0.5)            
     account_input.clear()
-    password_input.clear()
     account_input.send_keys(u)
+    
+    password_input.click()     
+    time.sleep(0.5)            
+    password_input.clear()
     password_input.send_keys(p)
-    # 执行脚本生成隐藏的随机验证码，并登录
+        # 执行脚本生成隐藏的随机验证码，并登录
     chrome.execute_script('arguments[0].click()', login_bt)
     # ActionChains(driver=chrome).move_to_element(login_bt).click(login_bt)
     # login_bt.click()
@@ -76,7 +100,7 @@ def login(chrome, u='', p=''):
 def init_chrome(host):
     chrome_options = Options()
     # 设置chrome浏览器无界面模式
-    chrome_options.add_argument('--headless')  # 无头模式
+    # chrome_options.add_argument('--headless')  # 无头模式
     chrome_options.add_argument('--disable-gpu')  # 不弹出界面
     chrome_options.add_argument('--incognito')  # 无痕隐身模式
     chrome_options.add_argument("disable-cache")    # 禁用缓存
@@ -97,42 +121,62 @@ def init_chrome(host):
 
 
 if __name__ == '__main__':
-    user_cfg_path = 'configurations.json'
+    user_cfg_path = 'configuration.json'
     user_config = None
+    
     try:
-        with open(user_cfg_path, 'r', encoding='utf8') as f:
+        with open(user_cfg_path, 'r', encoding='utf-8') as f:
             user_config = json.load(f)
-    except FileNotFoundError as e:
-        # print('配置文件 configurations.json 不存在。')
-        logger.error('配置文件 configurations.json 不存在。')
+    except FileNotFoundError:
+        logger.error(f"错误：配置文件 '{user_cfg_path}' 不存在，请检查文件名和路径。")
+        exit() # 文件不存在，程序无法继续
+    except json.JSONDecodeError:
+        logger.error(f"错误：配置文件 '{user_cfg_path}' 格式不正确，请检查是否为标准JSON。")
+        exit() # JSON格式错误，程序无法继续
+    except Exception as e:
+        logger.error(f"读取配置文件时发生未知错误: {e}")
+        exit()
+    
+    try:
+        host = user_config['daemon']['host']
+        account = user_config['login']['account']
+        password = user_config['login']['password']
+        delay = user_config['daemon']['frequencies']
+    except KeyError as e:
+        logger.error(f"错误：配置文件中缺少必要的键（Key）：{e}。请检查配置文件结构。")
         exit()
 
-    host = user_config['daemon']['host']
+    logger.info("正在初始化浏览器...")
     chrome = init_chrome(host)
+    if not chrome:
+        logger.error("浏览器初始化失败，程序退出。")
+        exit()
 
-    account = user_config['login']['account']
-    password = user_config['login']['password']
-
-    delay = user_config['daemon']['frequencies']
-    # print('后台运行维持网络连接。')
-    logger.info('后台运行维持网络连接。')
-    msg = ''
-    dt = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+    logger.info("初始化完成，开始后台监控网络连接...")
+       
     while True:
-        # time.sleep(delay)
-        try:
-            print(f'\r检查网络连接中。', end='')
+        try:            
             s, m = check(chrome, host)
             dt = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-            if not s:
-                login(chrome, account, password)
-            msg = m[:min(7, len(m))]
-        except Exception as e:
-            logger.error(f'登录或状态检查出错。', exc_info=True)
-        t = delay
-        for i in range(t, 0, -1):
-            print(f'\r当前状态：{msg} [{dt}]，下一次检查：{i}s', end='')
-            time.sleep(1)
-    chrome.close()
 
-    logger.info('\n程序终止。')
+            if not s:                
+                print(f'\n[{dt}] 状态：{m} 尝试登录...')
+                login(chrome, account, password)
+                time.sleep(3) # 登录后等待3秒让页面稳定
+                # 再次检查状态以确认登录结果
+                s, m = check(chrome, host)
+                dt = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+           
+            if s:
+                msg = f"已成功登录。[{dt}]"
+            else:
+                msg = f"尝试登录后仍未登录。[{dt}]"
+                        
+            for i in range(delay, 0, -1):
+                print(f'\r{msg} 下次检查还剩: {i}秒', end='')
+                time.sleep(1)
+
+        except Exception as e:
+            logger.error(f'\n主循环发生严重错误: {e}', exc_info=True)
+            logger.info("程序将在30秒后尝试恢复...")
+            time.sleep(30)


### PR DESCRIPTION
由于校园网登陆界面改版，我重新抓了一下XPath，然后增加了选择运营商的步骤，这些修改我在本地测试过了，运行正常

移动：//*[@id="edit_body"]/div[2]/div[12]/select/option[3]
校园网：//*[@id="edit_body"]/div[2]/div[12]/select/option[2]
电信：//*[@id="edit_body"]/div[2]/div[12]/select/option[4]
联通：//*[@id="edit_body"]/div[2]/div[12]/select/option[5]
用户名：//*[@id="edit_body"]/div[2]/div[12]/form/input[3]
密码：//*[@id="edit_body"]/div[2]/div[12]/form/input[4]
漫游免认证：//*[@id="edit_body"]/div[2]/div[12]/div[2]/font
登录：//*[@id="edit_body"]/div[2]/div[12]/form/input[2]
充值：//*[@id="edit_body"]/div[2]/div[12]/form/input[1]